### PR TITLE
Add history screen for past analyses

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation project(':core:ui')
     implementation project(':feature:camera')
     implementation project(':feature:damage-analysis')
+    implementation project(':feature:history')
 
     // Core Android
     implementation 'androidx.core:core-ktx:1.12.0'

--- a/app/src/main/java/com/cardamageai/navigation/CarDamageNavigation.kt
+++ b/app/src/main/java/com/cardamageai/navigation/CarDamageNavigation.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.cardamageai.feature.camera.CameraScreen
 import com.cardamageai.feature.damageanalysis.DamageAnalysisScreen
+import com.cardamageai.feature.history.HistoryScreen
 
 @Composable
 fun CarDamageNavigation(navController: NavHostController) {
@@ -18,10 +18,13 @@ fun CarDamageNavigation(navController: NavHostController) {
             CameraScreen(
                 onImageCaptured = { imageUri ->
                     navController.navigate("damage_analysis/$imageUri")
+                },
+                onHistoryClick = {
+                    navController.navigate("history")
                 }
             )
         }
-        
+
         composable("damage_analysis/{imageUri}") { backStackEntry ->
             val imageUri = backStackEntry.arguments?.getString("imageUri") ?: ""
             DamageAnalysisScreen(
@@ -29,6 +32,12 @@ fun CarDamageNavigation(navController: NavHostController) {
                 onBackPressed = {
                     navController.popBackStack()
                 }
+            )
+        }
+
+        composable("history") {
+            HistoryScreen(
+                onBackPressed = { navController.popBackStack() }
             )
         }
     }

--- a/feature/camera/src/main/java/com/cardamageai/feature/camera/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/cardamageai/feature/camera/CameraScreen.kt
@@ -1,6 +1,5 @@
 package com.cardamageai.feature.camera
 
-import android.net.Uri
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.view.CameraController
@@ -9,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -30,6 +30,7 @@ import java.util.*
 @Composable
 fun CameraScreen(
     onImageCaptured: (String) -> Unit,
+    onHistoryClick: () -> Unit,
     viewModel: CameraViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -47,6 +48,7 @@ fun CameraScreen(
         cameraPermission.status.isGranted -> {
             CameraContent(
                 onImageCaptured = onImageCaptured,
+                onHistoryClick = onHistoryClick,
                 viewModel = viewModel
             )
         }
@@ -61,6 +63,7 @@ fun CameraScreen(
 @Composable
 private fun CameraContent(
     onImageCaptured: (String) -> Unit,
+    onHistoryClick: () -> Unit,
     viewModel: CameraViewModel
 ) {
     val context = LocalContext.current
@@ -97,6 +100,18 @@ private fun CameraContent(
                 text = "Наведите камеру на повреждение автомобиля",
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.padding(16.dp)
+            )
+        }
+
+        IconButton(
+            onClick = onHistoryClick,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.History,
+                contentDescription = "История"
             )
         }
 

--- a/feature/history/build.gradle
+++ b/feature/history/build.gradle
@@ -1,0 +1,62 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+}
+
+android {
+    namespace 'com.cardamageai.feature.history'
+    compileSdk 34
+
+    defaultConfig {
+        minSdk 26
+        targetSdk 34
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles "consumer-rules.pro"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+    }
+}
+
+dependencies {
+    implementation project(':core:common')
+    implementation project(':core:ui')
+    implementation project(':core:database')
+
+    implementation 'androidx.core:core-ktx:1.12.0'
+
+    // Compose
+    implementation platform('androidx.compose:compose-bom:2023.10.01')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
+
+    // Image loading
+    implementation 'io.coil-kt:coil-compose:2.5.0'
+
+    // Hilt
+}

--- a/feature/history/src/main/java/com/cardamageai/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/com/cardamageai/feature/history/HistoryScreen.kt
@@ -1,0 +1,94 @@
+package com.cardamageai.feature.history
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import androidx.compose.ui.layout.ContentScale
+import com.cardamageai.core.database.entities.DamageAnalysisEntity
+import java.text.SimpleDateFormat
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HistoryScreen(
+    onBackPressed: () -> Unit,
+    viewModel: HistoryViewModel = hiltViewModel()
+) {
+    val analyses by viewModel.analyses.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("История анализов") },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Назад"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+        ) {
+            items(analyses) { analysis ->
+                HistoryItem(analysis = analysis)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryItem(analysis: DamageAnalysisEntity) {
+    val dateFormat = remember { SimpleDateFormat("dd MMM yyyy, HH:mm") }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Row(modifier = Modifier.padding(16.dp)) {
+            AsyncImage(
+                model = analysis.imageUri,
+                contentDescription = null,
+                modifier = Modifier.size(80.dp),
+                contentScale = ContentScale.Crop
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = analysis.damageType,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Серьёзность: ${analysis.severityLevel}/5",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = dateFormat.format(Date(analysis.timestamp)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/feature/history/src/main/java/com/cardamageai/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/com/cardamageai/feature/history/HistoryViewModel.kt
@@ -1,0 +1,21 @@
+package com.cardamageai.feature.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cardamageai.core.database.dao.DamageAnalysisDao
+import com.cardamageai.core.database.entities.DamageAnalysisEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    damageAnalysisDao: DamageAnalysisDao
+) : ViewModel() {
+
+    val analyses: StateFlow<List<DamageAnalysisEntity>> =
+        damageAnalysisDao.getAllAnalyses()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,3 +25,4 @@ include ':core:ui'
 // Feature modules
 include ':feature:camera'
 include ':feature:damage-analysis'
+include ':feature:history'


### PR DESCRIPTION
## Summary
- add history feature module with screen and viewmodel
- integrate history route and navigation button from camera screen
- wire up module in settings and app dependencies

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3491900483238ca500e9fd6ca6ce